### PR TITLE
Fix repo link

### DIFF
--- a/repos-db.json
+++ b/repos-db.json
@@ -17,7 +17,7 @@
     "https://raw.githubusercontent.com/AirbnbEcoPlus/frencharchive/master/repo.json",
     "https://codeberg.org/cloudstream/cloudstream-extensions-horis/raw/branch/master/repo.json",
     "https://codeberg.org/7TE/FStream/raw/branch/build/repo.json",
-    "https://techtanic.xyz/cs3ss",
+    "https://raw.githubusercontent.com/techtanic/SkillShare-Repo/builds/repo.json",
     "https://raw.githubusercontent.com/KillerDogeEmpire/avocado-extensions/builds/repo.json",
     "https://raw.githubusercontent.com/keyiflerolsun/Kekik-cloudstream/master/repo.json",
     "https://codeberg.org/IndusAryan/AR/raw/branch/main/repo.json",


### PR DESCRIPTION
Seems to be causing check_issue.py to throw:
```st
Traceback (most recent call last):
  File "/home/runner/work/cloudstream/cloudstream/./check_issue.py", line 58, in <module>
    plugin_names = asyncio.run(fetch_names())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/home/runner/work/cloudstream/cloudstream/./check_issue.py", line 46, in fetch_names
    res = await asyncio.gather(*[fetch_names_repo(x) for x in urls])
  File "/home/runner/work/cloudstream/cloudstream/./check_issue.py", line 31, in fetch_names_repo
    dat = r.json()
  File "/home/runner/.local/lib/python3.10/site-packages/httpx/_models.py", line 761, in json
    return jsonlib.loads(self.content, **kwargs)
  File "/usr/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```