### PR TITLE
French CS3 Extensions repo is down

### DIFF
--- a/repos-db.json
+++ b/repos-db.json
@@ -13,7 +13,6 @@
     "https://raw.githubusercontent.com/CakesTwix/cloudstream-extensions-uk/master/repo.json",
     "https://codeberg.org/cloudstream/cs3xxx-repo/raw/branch/dev/repo.json",
     "https://codeberg.org/cloudstream/arab/raw/branch/builds/repo.json",
-    "https://raw.githubusercontent.com/AirbnbEcoPlus/frencharchive/master/repo.json",
     "https://codeberg.org/cloudstream/cloudstream-extensions-horis/raw/branch/master/repo.json",
     "https://raw.githubusercontent.com/techtanic/SkillShare-Repo/builds/repo.json",
     "https://raw.githubusercontent.com/Rowdy-Avocado/Rowdycado-Extensions/builds/repo.json",


### PR DESCRIPTION
The French CS3 Extensions Github page hosting the french extensions and providers got removed for an unknown reason