### PR TITLE
Update repos-db.json

### DIFF
--- a/repos-db.json
+++ b/repos-db.json
@@ -26,5 +26,6 @@
     "https://raw.githubusercontent.com/Kraptor123/cs-Karma/refs/heads/master/repo.json",
     "https://raw.githubusercontent.com/redblacker8/storm-ext/refs/heads/builds/repo.json",
     "https://raw.githubusercontent.com/rockhero1234/cinephile/refs/heads/builds/repo.json",
-    "https://raw.githubusercontent.com/med1245/cartoonyrepo/builds/repo.json"
+    "https://raw.githubusercontent.com/med1245/cartoonyrepo/builds/repo.json",
+    "https://raw.githubusercontent.com/mouradchaouche/cloudstream-frenchrepo/main/repo.json"
 ]


### PR DESCRIPTION
Hi maintainers! 👋

I'm requesting a shortcode for this repository to make it easier for users to add it in CloudStream.

Repository Details:

Name: AMSC-FR (Mourad's French Repo)
Language: French
Description: CloudStream French providers/plugins repository
Repository URL: https://raw.githubusercontent.com/mouradchaouche/cloudstream-frenchrepo/main/repo.json
Requested Shortcode: amsc-fr

This would allow users to simply enter amsc-fr when adding a repository in CloudStream, instead of having to remember the full URL.

Would you be able to support this? If shortcodes need to be hardcoded in the app, I understand. Otherwise, please let me know if there's a shortcode mapping system I should use.

Thanks! 🚀