### PR TITLE
Register BetbetMiro-Extension repository in the CloudStream repository database.

### DIFF
--- a/repos-db.json
+++ b/repos-db.json
@@ -26,5 +26,6 @@
     "https://raw.githubusercontent.com/redblacker8/storm-ext/refs/heads/builds/repo.json",
     "https://raw.githubusercontent.com/rockhero1234/cinephile/refs/heads/builds/repo.json",
     "https://raw.githubusercontent.com/med1245/cartoonyrepo/builds/repo.json",
-    "https://raw.githubusercontent.com/Reflex755/ReflexRepo/refs/heads/builds/repo.json"
+    "https://raw.githubusercontent.com/Reflex755/ReflexRepo/refs/heads/builds/repo.json",
+    "https://raw.githubusercontent.com/sad25kag/BetbetMiro-Extension/master/repo.json"
 ]

--- a/test.json
+++ b/test.json
@@ -1,8 +1,9 @@
 {
-  "name": "Testing repository",
-  "description": "Lorem ipsum",
+  "name": "BetbetMiro-Extension",
+  "description": "Repository extension CloudStream custom berisi berbagai provider anime, donghua, movie, dan source streaming lainnya.",
+  "iconUrl": "https://avatars.githubusercontent.com/u/114850487?v=4",
   "manifestVersion": 1,
   "pluginLists": [
-    "https://raw.githubusercontent.com/recloudstream/TestPlugins/builds/plugins.json"
+    "https://raw.githubusercontent.com/sad25kag/BetbetMiro-Extension/builds/plugins.json"
   ]
 }


### PR DESCRIPTION
This PR adds the BetbetMiro-Extension repository to the CloudStream repository list.

Repository:
https://raw.githubusercontent.com/sad25kag/BetbetMiro-Extension/master/repo.json

Plugin list:
https://raw.githubusercontent.com/sad25kag/BetbetMiro-Extension/builds/plugins.json

Changes:

- Add BetbetMiro repository entry to repos-db.json
- Update test.json with BetbetMiro repository metadata
- Keep plugin artifacts served from the builds branch